### PR TITLE
bug suppression exercice

### DIFF
--- a/mathalea.js
+++ b/mathalea.js
@@ -570,6 +570,13 @@ import { menuDesExercicesDisponibles, dictionnaireDesExercices } from "./modules
             .then(() => {
                 // Récupère les paramètres passés dans l'URL
                 let urlVars = getUrlVars();
+				//trier et mettre de côté les urlvars qui ne sont plus dans la liste des exercices
+				//	=> évite les erreurs lors de la suppression de question dans la liste.
+				for (var i = 0; i < urlVars.length; i++) {
+					if (urlVars[i].id != liste_des_exercices[i]) {
+						urlVars.splice(i,1);
+					}	
+				}
                 for (var i = 0; i < urlVars.length; i++) {
                     // récupère les éventuels paramètres dans l'URL
                     // et les recopie dans les formulaires des paramètres

--- a/mathalea.js
+++ b/mathalea.js
@@ -398,10 +398,8 @@ import { menuDesExercicesDisponibles, dictionnaireDesExercices } from "./modules
 
         if (!sortie_html) {
             // Gestion du téléchargement
-
-            $("#btn_telechargement").click(function () {
+            $("#btn_telechargement").off("click").on("click",function () {
                 // Gestion du style pour l'entête du fichier
-
                 let contenu_fichier = `
     
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -434,8 +432,8 @@ import { menuDesExercicesDisponibles, dictionnaireDesExercices } from "./modules
                     telechargeFichier(contenu_fichier, "mathalea.tex");
                 }
             });
-
-            $("#btn_overleaf").click(function () {
+			
+			$("#btn_overleaf").off("click").on("click", function () {
                 // Gestion du style pour l'entête du fichier
 
                 let contenu_fichier = `


### PR DESCRIPTION
lorsqu'on supprimait un exercice dans la liste des exercices il y avait un bug qui empêchait la mise à jour des exercices.
Ajout d'un test pour vérifier que ce qu'on récupère de l'url est cohérent avec la liste des exercices proposés.
+
telechargement de plusieurs fois le même fichier dans mathalealatex si plusieurs exercices.