### PR TITLE
division continue à tort

### DIFF
--- a/modules/operations.js
+++ b/modules/operations.js
@@ -34,7 +34,7 @@ export default function Operation({ operande1 = 1, operande2 = 2, type = 'additi
 
      let DivisionPosee3d = function (divid, divis,precision=0) {
         let objets = [],zeroutile=false,periode=0
-        precision=Math.min(precision,nombreDeChiffresApresLaVirgule(divid/divis))
+        precision=Math.min(precision,nombreDeChiffresApresLaVirgule(calcul(divid/divis)))
         let decalage= nombreDeChiffresApresLaVirgule(divis)
         let dec1=nombreDeChiffresApresLaVirgule(divid)
         if (divid<divis) 


### PR DESCRIPTION
Problème signalé dans le cadre du 6C31 des divisions continuaient alors que le reste était nul.
Ajout de l'utilisation de la fonction calcul pour éviter certaines erreurs de calculs avec des décimaux lors de la détermination de la précision.